### PR TITLE
Some fixes, Adding the option to save the local vars in a file, instead of in config

### DIFF
--- a/2.0/ubuntu12/install.sh
+++ b/2.0/ubuntu12/install.sh
@@ -871,7 +871,7 @@ EOF
 chmod 0440 /etc/sudoers.d/baruwa
 fi
 
-if [[-f $track/exim && -f $eximdir/baruwa/exim-bcrypt.pl ]];
+if [[ -f $track/exim && -f $eximdir/baruwa/exim-bcrypt.pl ]];
         then
         echo "Exim is already configured. Skipping"; sleep 3
 else


### PR DESCRIPTION
The last pull requests allows you to put your vars into ./local_vars , that way you can keep your own config while fetching the installer from github.

I also fixed a fair few typos, and a fix for amd64 having a different download url for libdigest-sha1-perl
