### PR TITLE
Edit freshclam to set av database to correct location

### DIFF
--- a/2.0/centos/install.sh
+++ b/2.0/centos/install.sh
@@ -1058,6 +1058,7 @@ f_clam (){
 		chown -R clamav:clamav /var/lib/clamav
 		touch /var/log/clamav/freshclam.log
 		sed -i -e 's:var/clamav:var/lib/clamav:' /etc/clamd.conf
+		sed -i -e 's:var/clamav:var/lib/clamav:' /etc/freshclam.conf
 		sed -i -e 's:CHANGE:'$pssqlpass':' /etc/MailScanner/spam.assassin.prefs.conf
 		sed -i -e '19 s:usr/local:usr:' /etc/MailScanner/virus.scanners.conf
 		fn_clear


### PR DESCRIPTION
[root@baruwa1 ~]# service clamd restart
Stopping Clam AntiVirus Daemon:                            [  OK  ]
Starting Clam AntiVirus Daemon: LibClamAV Error: cli_loaddb(): No supported database files found in /var/lib/clamav
ERROR: Can't open file or directory
                                                           [FAILED]
