### PR TITLE
Exclude perl-Compress-Raw-Zlib from CentOS updates

### DIFF
--- a/centos/install.sh
+++ b/centos/install.sh
@@ -524,7 +524,7 @@ else
 			echo "Skipping"; sleep 2
 	else
 	sed -i "19i exclude=perl-Compress-Raw-Zlib perl-Archive-Zip perl-Compress-Zlib perl-libwww-perl spamassassin perl-IO-Zlib perl-DBI" /etc/yum.repos.d/CentOS-Base.repo
-	sed -i "28i exclude=spamassassin" /etc/yum.repos.d/CentOS-Base.repo
+	sed -i "28i exclude=spamassassin perl-Compress-Raw-Zlib" /etc/yum.repos.d/CentOS-Base.repo
 	touch $track/cent-exclude
 	fi
 


### PR DESCRIPTION
need to exclude this from updates as its causing install fail on dependencies. 
http://mirror.centos.org/centos/6.5/os/x86_64/Packages/ only holds perl-Compress-Zlib-2.021-136.el6.x86_64.rpm to the 2.052 version required.

2.052 is then found in rpmforge-extras
